### PR TITLE
Bugfix to make fingerprint computation consistent with C++ and JS impls

### DIFF
--- a/negentropy/src/types.rs
+++ b/negentropy/src/types.rs
@@ -210,9 +210,9 @@ impl Accumulator {
 
         let mut wtr = Vec::with_capacity(ID_SIZE);
 
-        for _ in 0..4 {
-            let orig = Wrapping(u64::from_le_bytes(p[..8].try_into()?));
-            let other_v = Wrapping(u64::from_le_bytes(po[..8].try_into()?));
+        for i in 0..4 {
+            let orig = Wrapping(u64::from_le_bytes(p[(i*8)..(i*8 + 8)].try_into()?));
+            let other_v = Wrapping(u64::from_le_bytes(po[(i*8)..(i*8 + 8)].try_into()?));
 
             let mut next = orig;
 


### PR DESCRIPTION
Hi Yuki,

Sorry for the delay! The delta comparisons of the harness tests were not passing, meaning the output between C++/JS and Rust were not identical. I figured out the issue and now all the tests pass.

Thank you!

Doug